### PR TITLE
Add Moo module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN curl -fsSL https://raw.githubusercontent.com/skaji/cpm/main/cpm | perl - install -g Test2::V0 App::Yath
+RUN curl -fsSL https://raw.githubusercontent.com/skaji/cpm/main/cpm | perl - install -g Test2::V0 App::Yath Moo
 
 WORKDIR /opt/test-runner
 COPY . .

--- a/tests/example-success/Leap.pm
+++ b/tests/example-success/Leap.pm
@@ -5,6 +5,9 @@ use warnings;
 use Exporter qw<import>;
 our @EXPORT_OK = qw<is_leap_year>;
 
+# For checking module presence in test runner
+use Moo;
+
 sub is_leap_year {
   my ($year) = @_;
   return $year % 4 == 0 && $year % 100 != 0 || $year % 400 == 0;


### PR DESCRIPTION
The clock exercise stub uses the module Moo for OO. Previously this would have been installed locally, but I don't currently have a solution for installing dependencies per exercise in the test runner.

Include the module so the stub does not have to be rewritten (and because writing an OO package with no OO system in perl is a bit annoying).