### PR TITLE
Create perl script generating results wih test output support

### DIFF
--- a/bin/run-tests.sh
+++ b/bin/run-tests.sh
@@ -29,7 +29,7 @@ for test_dir in tests/*; do
       -e "s~${test_dir_path}~/solution~g" \
       -e "s~${test_dir}~/solution~g" \
       -e "s/ \(@INC contains:.*?\)//g" \
-      -e "s/T2-HARNESS.*?utf8\\\n//g" \
+      -e "s/Seeded srand.*?\\\n//g" \
       "${results_file_path}"
 
     echo "${test_dir_name}: comparing results.json to expected_results.json"

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -35,21 +35,6 @@ echo "${slug}: testing..."
 yath test "${input_dir}/${slug}.t" -qq --log-file $input_dir/log.jsonl
 
 # Transform log data to expected output
-cat $input_dir/log.jsonl | jq --slurp '
-  {
-    version:   2,
-    exit_code: (.[].facet_data.harness_job_exit.code // empty),
-    message:   (.[].facet_data.harness_job_exit.stderr // empty),
-    tests:     ([.[].facet_data | if .assert.pass == 1 then {name: .assert.details, status: "pass"} elif .assert.pass == 0 then {name: .assert.details, status: "fail", message: .info[0].details} else empty end])
-  } | if .tests[0] and .exit_code == "0" then
-    {version, status: "pass", tests}
-  elif .tests[0] and .exit_code != "255" then
-    {version, status: "fail", tests}
-  elif .tests[0] then
-    {version, status: "error", message, tests}
-  else
-    {version, status: "error", message}
-  end
-' > ${results_file}
+cat $input_dir/log.jsonl | bin/transform_logs.pl > ${results_file}
 
 echo "${slug}: done"

--- a/bin/transform_logs.pl
+++ b/bin/transform_logs.pl
@@ -1,0 +1,87 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use JSON::PP   ();
+use List::Util qw<none>;
+
+my $json = JSON::PP->new->utf8->allow_nonref->canonical->pretty;
+
+my %out = (
+    version => 2,
+    status  => 'pass',
+    tests   => [],
+);
+
+my %test_debug;
+while ( my $line = <> ) {
+    if ( length( $test_debug{STDOUT} // '' ) > 500 ) {
+        $test_debug{STDOUT} = substr( $test_debug{STDOUT}, 0, 500 )
+            . '... Output was truncated. Please limit to 500 chars.';
+    }
+    my $data = $json->decode($line);
+    next if ref $data ne 'HASH';
+
+    my $facet = $data->{facet_data} // {};
+
+    # Check for error messages, fail for bad tests, error otherwise.
+    if ( my @errors = @{ $facet->{errors} // [] } ) {
+        if ( @{ $out{tests} } ) {
+            $out{status} = 'fail';
+
+            # Something has gone wrong with a test if the plan didn't pan out
+            if ( none { $_->{details} =~ /^Assertion failures/ } @errors ) {
+                push @{ $out{tests} },
+                    {
+                    name    => 'Unknown: An error occurred.',
+                    status  => 'error',
+                    output  => $test_debug{STDOUT},
+                    message => join '',
+                    map { $_ // '' } @test_debug{qw<STDERR DIAG REASON>},
+                    };
+            }
+        }
+
+        # Errors with no tests
+        else {
+            $out{status} = 'error';
+            delete $out{tests};
+            $out{message} = join '',
+                map { $_ // '' } @test_debug{qw<STDERR DIAG REASON>};
+        }
+    }
+
+    # Check if a test exists and whether it has passed or failed
+    elsif ( defined $facet->{assert}{pass} ) {
+        my $message = $test_debug{STDERR};
+        my $diag    = join '', map { $_->{details} }
+            grep { $_->{tag} eq 'DIAG' } @{ $facet->{info} // [] };
+
+        if ( $diag && !$facet->{assert}{pass} ) {
+            $message .= "\n" if $message;
+            $message .= $diag;
+        }
+
+        push @{ $out{tests} },
+            {
+            name   => $facet->{assert}{details},
+            status => $facet->{assert}{pass} ? 'pass' : 'fail',
+            output => $test_debug{STDOUT},
+            ( message => $message ) x !!$message,
+            };
+
+        $test_debug{STDOUT} = undef;
+        $test_debug{STDERR} = undef;
+
+    }
+
+    # If no test result, collect any output for the next test
+    else {
+        for ( @{ $facet->{info} // [] } ) {
+            $test_debug{ $_->{tag} } .= $_->{details} . "\n";
+        }
+    }
+}
+
+print $json->encode( \%out );

--- a/tests/example-all-fail/expected_results.json
+++ b/tests/example-all-fail/expected_results.json
@@ -1,20 +1,23 @@
 {
-  "version": 2,
-  "status": "fail",
-  "tests": [
-    {
-      "name": "Imported symbol: is_leap_year",
-      "status": "pass"
-    },
-    {
-      "name": "year not divisible by 4 in common year",
-      "status": "fail",
-      "message": "+-----+----------------------+-------------------+-----+\n| GOT | OP                   | CHECK             | LNs |\n+-----+----------------------+-------------------+-----+\n| 1   | DEFINED() && FALSE() | DEFINED BUT FALSE | 21  |\n+-----+----------------------+-------------------+-----+"
-    },
-    {
-      "name": "year divisible by 4, not divisible by 100 in leap year",
-      "status": "fail",
-      "message": "+-----+--------+-------+-----+\n| GOT | OP     | CHECK | LNs |\n+-----+--------+-------+-----+\n|     | TRUE() | TRUE  | 21  |\n+-----+--------+-------+-----+"
-    }
-  ]
+   "status" : "fail",
+   "tests" : [
+      {
+         "name" : "Imported symbol: is_leap_year",
+         "output" : null,
+         "status" : "pass"
+      },
+      {
+         "message" : "+-----+----------------------+-------------------+-----+\n| GOT | OP                   | CHECK             | LNs |\n+-----+----------------------+-------------------+-----+\n| 1   | DEFINED() && FALSE() | DEFINED BUT FALSE | 21  |\n+-----+----------------------+-------------------+-----+",
+         "name" : "year not divisible by 4 in common year",
+         "output" : null,
+         "status" : "fail"
+      },
+      {
+         "message" : "+-----+--------+-------+-----+\n| GOT | OP     | CHECK | LNs |\n+-----+--------+-------+-----+\n|     | TRUE() | TRUE  | 21  |\n+-----+--------+-------+-----+",
+         "name" : "year divisible by 4, not divisible by 100 in leap year",
+         "output" : null,
+         "status" : "fail"
+      }
+   ],
+   "version" : 2
 }

--- a/tests/example-die-mid-test/expected_results.json
+++ b/tests/example-die-mid-test/expected_results.json
@@ -1,11 +1,17 @@
 {
-  "version": 2,
-  "status": "error",
-  "message": "oh no at /solution/Leap.pm line 10, <DATA> line 25.\n",
-  "tests": [
-    {
-      "name": "Imported symbol: is_leap_year",
-      "status": "pass"
-    }
-  ]
+   "status" : "fail",
+   "tests" : [
+      {
+         "name" : "Imported symbol: is_leap_year",
+         "output" : null,
+         "status" : "pass"
+      },
+      {
+         "message" : "oh no at /solution/Leap.pm line 10, <DATA> line 25.\nLooks like your test exited with 255 after test #1.\nDid not follow plan: expected 3, ran 1.\n",
+         "name" : "Unknown: An error occurred.",
+         "output" : null,
+         "status" : "error"
+      }
+   ],
+   "version" : 2
 }

--- a/tests/example-empty-file/expected_results.json
+++ b/tests/example-empty-file/expected_results.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
-  "status": "error",
-  "message": "Leap.pm did not return a true value at /solution/leap.t line 9.\nBEGIN failed--compilation aborted at /solution/leap.t line 9.\n"
+   "message" : "Leap.pm did not return a true value at /solution/leap.t line 9.\nBEGIN failed--compilation aborted at /solution/leap.t line 9.\n",
+   "status" : "error",
+   "version" : 2
 }

--- a/tests/example-missing-module/expected_results.json
+++ b/tests/example-missing-module/expected_results.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
-  "status": "error",
-  "message": "Can't locate MyApp.pm in @INC (you may need to install the MyApp module) at /solution/Leap.pm line 8.\nBEGIN failed--compilation aborted at /solution/Leap.pm line 8.\nCompilation failed in require at /solution/leap.t line 9.\nBEGIN failed--compilation aborted at /solution/leap.t line 9.\n"
+   "message" : "Can't locate MyApp.pm in @INC (you may need to install the MyApp module) at /solution/Leap.pm line 8.\nBEGIN failed--compilation aborted at /solution/Leap.pm line 8.\nCompilation failed in require at /solution/leap.t line 9.\nBEGIN failed--compilation aborted at /solution/leap.t line 9.\n",
+   "status" : "error",
+   "version" : 2
 }

--- a/tests/example-partial-fail/expected_results.json
+++ b/tests/example-partial-fail/expected_results.json
@@ -1,48 +1,58 @@
 {
-  "version": 2,
-  "status": "fail",
-  "tests": [
-    {
-      "name": "Imported symbol: is_leap_year",
-      "status": "pass"
-    },
-    {
-      "name": "year not divisible by 4 in common year",
-      "status": "pass"
-    },
-    {
-      "name": "year divisible by 2, not divisible by 4 in common year",
-      "status": "pass"
-    },
-    {
-      "name": "year divisible by 4, not divisible by 100 in leap year",
-      "status": "pass"
-    },
-    {
-      "name": "year divisible by 4 and 5 is still a leap year",
-      "status": "pass"
-    },
-    {
-      "name": "year divisible by 100, not divisible by 400 in common year",
-      "status": "pass"
-    },
-    {
-      "name": "year divisible by 100 but not by 3 is still not a leap year",
-      "status": "pass"
-    },
-    {
-      "name": "year divisible by 400 is leap year",
-      "status": "fail",
-      "message": "+-----+--------+-------+-----+\n| GOT | OP     | CHECK | LNs |\n+-----+--------+-------+-----+\n|     | TRUE() | TRUE  | 21  |\n+-----+--------+-------+-----+"
-    },
-    {
-      "name": "year divisible by 400 but not by 125 is still a leap year",
-      "status": "fail",
-      "message": "+-----+--------+-------+-----+\n| GOT | OP     | CHECK | LNs |\n+-----+--------+-------+-----+\n|     | TRUE() | TRUE  | 21  |\n+-----+--------+-------+-----+"
-    },
-    {
-      "name": "year divisible by 200, not divisible by 400 in common year",
-      "status": "pass"
-    }
-  ]
+   "status" : "fail",
+   "tests" : [
+      {
+         "name" : "Imported symbol: is_leap_year",
+         "output" : null,
+         "status" : "pass"
+      },
+      {
+         "name" : "year not divisible by 4 in common year",
+         "output" : null,
+         "status" : "pass"
+      },
+      {
+         "name" : "year divisible by 2, not divisible by 4 in common year",
+         "output" : null,
+         "status" : "pass"
+      },
+      {
+         "name" : "year divisible by 4, not divisible by 100 in leap year",
+         "output" : null,
+         "status" : "pass"
+      },
+      {
+         "name" : "year divisible by 4 and 5 is still a leap year",
+         "output" : null,
+         "status" : "pass"
+      },
+      {
+         "name" : "year divisible by 100, not divisible by 400 in common year",
+         "output" : null,
+         "status" : "pass"
+      },
+      {
+         "name" : "year divisible by 100 but not by 3 is still not a leap year",
+         "output" : null,
+         "status" : "pass"
+      },
+      {
+         "message" : "+-----+--------+-------+-----+\n| GOT | OP     | CHECK | LNs |\n+-----+--------+-------+-----+\n|     | TRUE() | TRUE  | 21  |\n+-----+--------+-------+-----+",
+         "name" : "year divisible by 400 is leap year",
+         "output" : null,
+         "status" : "fail"
+      },
+      {
+         "message" : "+-----+--------+-------+-----+\n| GOT | OP     | CHECK | LNs |\n+-----+--------+-------+-----+\n|     | TRUE() | TRUE  | 21  |\n+-----+--------+-------+-----+",
+         "name" : "year divisible by 400 but not by 125 is still a leap year",
+         "output" : null,
+         "status" : "fail"
+      },
+      {
+         "name" : "year divisible by 200, not divisible by 400 in common year",
+         "output" : null,
+         "status" : "pass"
+      }
+   ],
+   "version" : 2
 }

--- a/tests/example-success/Leap.pm
+++ b/tests/example-success/Leap.pm
@@ -10,6 +10,7 @@ use Moo;
 
 sub is_leap_year {
   my ($year) = @_;
+  print "OUTPUT\n" if $year == 1970;
   return $year % 4 == 0 && $year % 100 != 0 || $year % 400 == 0;
 }
 

--- a/tests/example-success/expected_results.json
+++ b/tests/example-success/expected_results.json
@@ -1,46 +1,56 @@
 {
-  "version": 2,
-  "status": "pass",
-  "tests": [
-    {
-      "name": "Imported symbol: is_leap_year",
-      "status": "pass"
-    },
-    {
-      "name": "year not divisible by 4 in common year",
-      "status": "pass"
-    },
-    {
-      "name": "year divisible by 2, not divisible by 4 in common year",
-      "status": "pass"
-    },
-    {
-      "name": "year divisible by 4, not divisible by 100 in leap year",
-      "status": "pass"
-    },
-    {
-      "name": "year divisible by 4 and 5 is still a leap year",
-      "status": "pass"
-    },
-    {
-      "name": "year divisible by 100, not divisible by 400 in common year",
-      "status": "pass"
-    },
-    {
-      "name": "year divisible by 100 but not by 3 is still not a leap year",
-      "status": "pass"
-    },
-    {
-      "name": "year divisible by 400 is leap year",
-      "status": "pass"
-    },
-    {
-      "name": "year divisible by 400 but not by 125 is still a leap year",
-      "status": "pass"
-    },
-    {
-      "name": "year divisible by 200, not divisible by 400 in common year",
-      "status": "pass"
-    }
-  ]
+   "status" : "pass",
+   "tests" : [
+      {
+         "name" : "Imported symbol: is_leap_year",
+         "output" : null,
+         "status" : "pass"
+      },
+      {
+         "name" : "year not divisible by 4 in common year",
+         "output" : null,
+         "status" : "pass"
+      },
+      {
+         "name" : "year divisible by 2, not divisible by 4 in common year",
+         "output" : "OUTPUT\n",
+         "status" : "pass"
+      },
+      {
+         "name" : "year divisible by 4, not divisible by 100 in leap year",
+         "output" : null,
+         "status" : "pass"
+      },
+      {
+         "name" : "year divisible by 4 and 5 is still a leap year",
+         "output" : null,
+         "status" : "pass"
+      },
+      {
+         "name" : "year divisible by 100, not divisible by 400 in common year",
+         "output" : null,
+         "status" : "pass"
+      },
+      {
+         "name" : "year divisible by 100 but not by 3 is still not a leap year",
+         "output" : null,
+         "status" : "pass"
+      },
+      {
+         "name" : "year divisible by 400 is leap year",
+         "output" : null,
+         "status" : "pass"
+      },
+      {
+         "name" : "year divisible by 400 but not by 125 is still a leap year",
+         "output" : null,
+         "status" : "pass"
+      },
+      {
+         "name" : "year divisible by 200, not divisible by 400 in common year",
+         "output" : null,
+         "status" : "pass"
+      }
+   ],
+   "version" : 2
 }

--- a/tests/example-syntax-error/expected_results.json
+++ b/tests/example-syntax-error/expected_results.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
-  "status": "error",
-  "message": "Number found where operator expected at /solution/Leap.pm line 2, near \"@&31\"\n\t(Missing operator before 31?)\nsyntax error at /solution/Leap.pm line 2, near \"@&31\"\nCompilation failed in require at /solution/leap.t line 9.\nBEGIN failed--compilation aborted at /solution/leap.t line 9.\n"
+   "message" : "Number found where operator expected at /solution/Leap.pm line 2, near \"@&31\"\n\t(Missing operator before 31?)\nsyntax error at /solution/Leap.pm line 2, near \"@&31\"\nCompilation failed in require at /solution/leap.t line 9.\nBEGIN failed--compilation aborted at /solution/leap.t line 9.\n",
+   "status" : "error",
+   "version" : 2
 }


### PR DESCRIPTION
I wanted to add support for the `output` key in tests but doing so with `jq` was proving to be a challenge. I've replaced the `jq` filter with a perl script to make some improvements.