### PR TITLE
Add additional constant modules

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -25,6 +25,10 @@ requires 'DateTime::Tiny';
 requires 'Date::Tiny';
 requires 'Time::Tiny';
 
-# Misc
+# Constants
 requires 'Readonly';
+requires 'ReadonlyX';
+requires 'Const::Fast';
+
+# Types
 requires 'Type::Tiny';


### PR DESCRIPTION
The `Readonly` module is said to have flaws, which other modules have addressed: https://metacpan.org/pod/ReadonlyX#ReadonlyX-vs.-Readonly