### PR TITLE
Fix encoding issues with non-ASCII characters

### DIFF
--- a/bin/transform-results.pl
+++ b/bin/transform-results.pl
@@ -11,7 +11,7 @@ sub run ($tap_results, $output_file, $test_file) {
     my $output = ''; 
     my $take   = false;
     my (@case, $case_id, $task_id);
-    my $json = Cpanel::JSON::XS->new->canonical->pretty->utf8;
+    my $json = Cpanel::JSON::XS->new->canonical->pretty->ascii;
 
     my %results = (
         status  => 'error',
@@ -26,7 +26,7 @@ sub run ($tap_results, $output_file, $test_file) {
             $case_id = $1;
             $task_id = $2;
         }
-        
+
         if ($take) {
             push @case, ($line =~ s/# \w+: $case_id.*//r);
 

--- a/cpanfile
+++ b/cpanfile
@@ -2,6 +2,7 @@
 requires 'App::cpm';
 requires 'Cpanel::JSON::XS';
 requires 'Path::Tiny';
+requires 'Unicode::GCString';
 
 # Dumping
 requires 'Data::Dumper';

--- a/tests/example-unicode/expected_results.json
+++ b/tests/example-unicode/expected_results.json
@@ -1,0 +1,80 @@
+{
+   "message" : null,
+   "status" : "fail",
+   "tests" : [
+      {
+         "message" : "# Failed test 'English language short'\n# at /solution/t/leap.t line 9.\n# +---------+-------+\n# | GOT     | CHECK |\n# +---------+-------+\n# | <UNDEF> | Hi    |\n# +---------+-------+\n",
+         "name" : "English language short",
+         "status" : "fail",
+         "test_code" : "is( \n    truncate_post(\"Hi\"),\n    'Hi',\n    'English language short',\n);"
+      },
+      {
+         "message" : "# Failed test 'English language long'\n# at /solution/t/leap.t line 15.\n# +---------+-------+\n# | GOT     | CHECK |\n# +---------+-------+\n# | <UNDEF> | Hello |\n# +---------+-------+\n",
+         "name" : "English language long",
+         "status" : "fail",
+         "test_code" : "is( \n    truncate_post(\"Hello there\"),\n    'Hello',\n    'English language long',\n);"
+      },
+      {
+         "message" : "# Failed test 'German language short (broth)'\n# at /solution/t/leap.t line 21.\n# +---------+-------+\n# | GOT     | CHECK |\n# +---------+-------+\n# | <UNDEF> | br\u00fche |\n# +---------+-------+\n",
+         "name" : "German language short (broth)",
+         "status" : "fail",
+         "test_code" : "is( \n    truncate_post(\"br\\xC3\\xBChe\"),\n    'br\u00fche',\n    'German language short (broth)',\n);"
+      },
+      {
+         "message" : "# Failed test 'German language long (bear carpet \u2192 beards)'\n# at /solution/t/leap.t line 27.\n# +---------+-------+\n# | GOT     | CHECK |\n# +---------+-------+\n# | <UNDEF> | B\u00e4rte |\n# +---------+-------+\n",
+         "name" : "German language long (bear carpet \u2192 beards)",
+         "status" : "fail",
+         "test_code" : "is( \n    truncate_post(\"B\\xC3\\xA4rteppich\"),\n    'B\u00e4rte',\n    'German language long (bear carpet \u2192 beards)',\n);"
+      },
+      {
+         "message" : "# Failed test 'Bulgarian language short (good)'\n# at /solution/t/leap.t line 33.\n# +---------+-------+\n# | GOT     | CHECK |\n# +---------+-------+\n# | <UNDEF> | \u0414\u043e\u0431\u044a\u0440 |\n# +---------+-------+\n",
+         "name" : "Bulgarian language short (good)",
+         "status" : "fail",
+         "test_code" : "is( \n    truncate_post(\"\\xD0\\x94\\xD0\\xBE\\xD0\\xB1\\xD1\\x8A\\xD1\\x80\"),\n    '\u0414\u043e\u0431\u044a\u0440',\n    'Bulgarian language short (good)',\n);"
+      },
+      {
+         "message" : "# Failed test 'Greek language short (health)'\n# at /solution/t/leap.t line 39.\n# +---------+-------+\n# | GOT     | CHECK |\n# +---------+-------+\n# | <UNDEF> | \u03c5\u03b3\u03b5\u03b9\u03ac |\n# +---------+-------+\n",
+         "name" : "Greek language short (health)",
+         "status" : "fail",
+         "test_code" : "is( \n    truncate_post(\"\\xCF\\x85\\xCE\\xB3\\xCE\\xB5\\xCE\\xB9\\xCE\\xAC\"),\n    '\u03c5\u03b3\u03b5\u03b9\u03ac',\n    'Greek language short (health)',\n);"
+      },
+      {
+         "message" : "# Failed test 'Maths short'\n# at /solution/t/leap.t line 45.\n# +---------+-------+\n# | GOT     | CHECK |\n# +---------+-------+\n# | <UNDEF> | a=\u03c0r\u00b2 |\n# +---------+-------+\n",
+         "name" : "Maths short",
+         "status" : "fail",
+         "test_code" : "is( \n    truncate_post(\"a=\\xCF\\x80r\\xC2\\xB2\"),\n    'a=\u03c0r\u00b2',\n    'Maths short',\n);"
+      },
+      {
+         "message" : "# Failed test 'Maths long'\n# at /solution/t/leap.t line 51.\n# +---------+-------+\n# | GOT     | CHECK |\n# +---------+-------+\n# | <UNDEF> | \u2205\u228a\u2115\u228a\u2124 |\n# +---------+-------+\n",
+         "name" : "Maths long",
+         "status" : "fail",
+         "test_code" : "is( \n    truncate_post(\"\\xE2\\x88\\x85\\xE2\\x8A\\x8A\\xE2\\x84\\x95\\xE2\\x8A\\x8A\\xE2\\x84\\xA4\\xE2\\x8A\\x8A\\xE2\\x84\\x9A\\xE2\\x8A\\x8A\\xE2\\x84\\x9D\\xE2\\x8A\\x8A\\xE2\\x84\\x82\"),\n    '\u2205\u228a\u2115\u228a\u2124',\n    'Maths long',\n);"
+      },
+      {
+         "message" : "# Failed test 'English and emoji short'\n# at /solution/t/leap.t line 57.\n# +---------+-------+\n# | GOT     | CHECK |\n# +---------+-------+\n# | <UNDEF> | Fly \ud83d\udeeb |\n# +---------+-------+\n",
+         "name" : "English and emoji short",
+         "status" : "fail",
+         "test_code" : "is( \n    truncate_post(\"Fly \\xF0\\x9F\\x9B\\xAB\"),\n    'Fly \ud83d\udeeb',\n    'English and emoji short',\n);"
+      },
+      {
+         "message" : "# Failed test 'Emoji short'\n# at /solution/t/leap.t line 63.\n# +---------+-------+\n# | GOT     | CHECK |\n# +---------+-------+\n# | <UNDEF> | \ud83d\udc87     |\n# +---------+-------+\n",
+         "name" : "Emoji short",
+         "status" : "fail",
+         "test_code" : "is( \n    truncate_post(\"\\xF0\\x9F\\x92\\x87\"),\n    '\ud83d\udc87',\n    'Emoji short',\n);"
+      },
+      {
+         "message" : "# Failed test 'Emoji long'\n# at /solution/t/leap.t line 69.\n# +---------+-------+\n# | GOT     | CHECK |\n# +---------+-------+\n# | <UNDEF> | \u2744\ud83c\udf21\ud83e\udd27\ud83e\udd12\ud83c\udfe5 |\n# +---------+-------+\n",
+         "name" : "Emoji long",
+         "status" : "fail",
+         "test_code" : "is( \n    truncate_post(\"\\xE2\\x9D\\x84\\xF0\\x9F\\x8C\\xA1\\xF0\\x9F\\xA4\\xA7\\xF0\\x9F\\xA4\\x92\\xF0\\x9F\\x8F\\xA5\\xF0\\x9F\\x95\\xB0\\xF0\\x9F\\x98\\x80\"),\n    '\u2744\ud83c\udf21\ud83e\udd27\ud83e\udd12\ud83c\udfe5',\n    'Emoji long',\n);"
+      },
+      {
+         "message" : "# Failed test 'Royal Flush?'\n# at /solution/t/leap.t line 75.\n# +---------+-------+\n# | GOT     | CHECK |\n# +---------+-------+\n# | <UNDEF> | \ud83c\udcce\ud83c\udcb8\ud83c\udcc5\ud83c\udccb\ud83c\udccd |\n# +---------+-------+\n# ",
+         "name" : "Royal Flush?",
+         "status" : "fail",
+         "test_code" : "is( \n    truncate_post(\"\\xF0\\x9F\\x83\\x8E\\xF0\\x9F\\x82\\xB8\\xF0\\x9F\\x83\\x85\\xF0\\x9F\\x83\\x8B\\xF0\\x9F\\x83\\x8D\\xF0\\x9F\\x83\\x81\\xF0\\x9F\\x83\\x8A\"),\n    '\ud83c\udcce\ud83c\udcb8\ud83c\udcc5\ud83c\udccb\ud83c\udccd',\n    'Royal Flush?',\n);"
+      }
+   ],
+   "version" : 3
+}
+

--- a/tests/example-unicode/lib/Leap.pm
+++ b/tests/example-unicode/lib/Leap.pm
@@ -1,0 +1,12 @@
+package Leap;
+
+use v5.40;
+
+use Exporter qw<import>;
+our @EXPORT_OK = qw<truncate_post>;
+
+sub truncate_post ($utf8_bytes) {
+    return undef;
+}
+
+1;

--- a/tests/example-unicode/t/leap.t
+++ b/tests/example-unicode/t/leap.t
@@ -1,0 +1,81 @@
+#!/usr/bin/env perl
+use Test2::V0;
+
+use FindBin qw<$Bin>;
+use lib "$Bin/../lib", "$Bin/../local/lib/perl5";
+
+use Leap qw<truncate_post>;
+
+is( # begin: b927b57f-7c98-42fd-8f33-fae091dc1efc
+    truncate_post("Hi"),
+    'Hi',
+    'English language short',
+); # end: b927b57f-7c98-42fd-8f33-fae091dc1efc
+
+is( # begin: a3fcdc5b-0ed4-4f49-80f5-b1a293eac2a0
+    truncate_post("Hello there"),
+    'Hello',
+    'English language long',
+); # end: a3fcdc5b-0ed4-4f49-80f5-b1a293eac2a0
+
+is( # begin: 01910864-8e15-4007-9c7c-ac956c686e60
+    truncate_post("br\xC3\xBChe"),
+    'brühe',
+    'German language short (broth)',
+); # end: 01910864-8e15-4007-9c7c-ac956c686e60
+
+is( # begin: f263e488-aefb-478f-a671-b6ba99722543
+    truncate_post("B\xC3\xA4rteppich"),
+    'Bärte',
+    'German language long (bear carpet → beards)',
+); # end: f263e488-aefb-478f-a671-b6ba99722543
+
+is( # begin: 0916e8f1-41d7-4402-a110-b08aa000342c
+    truncate_post("\xD0\x94\xD0\xBE\xD0\xB1\xD1\x8A\xD1\x80"),
+    'Добър',
+    'Bulgarian language short (good)',
+); # end: 0916e8f1-41d7-4402-a110-b08aa000342c
+
+is( # begin: bed6b89c-03df-4154-98e6-a61a74f61b7d
+    truncate_post("\xCF\x85\xCE\xB3\xCE\xB5\xCE\xB9\xCE\xAC"),
+    'υγειά',
+    'Greek language short (health)',
+); # end: bed6b89c-03df-4154-98e6-a61a74f61b7d
+
+is( # begin: 485a6a70-2edb-424d-b999-5529dbc8e002
+    truncate_post("a=\xCF\x80r\xC2\xB2"),
+    'a=πr²',
+    'Maths short',
+); # end: 485a6a70-2edb-424d-b999-5529dbc8e002
+
+is( # begin: 8b4b7b51-8f48-4fbe-964e-6e4e6438be28
+    truncate_post("\xE2\x88\x85\xE2\x8A\x8A\xE2\x84\x95\xE2\x8A\x8A\xE2\x84\xA4\xE2\x8A\x8A\xE2\x84\x9A\xE2\x8A\x8A\xE2\x84\x9D\xE2\x8A\x8A\xE2\x84\x82"),
+    '∅⊊ℕ⊊ℤ',
+    'Maths long',
+); # end: 8b4b7b51-8f48-4fbe-964e-6e4e6438be28
+
+is( # begin: 71f4a192-0566-4402-a512-fe12878be523
+    truncate_post("Fly \xF0\x9F\x9B\xAB"),
+    'Fly 🛫',
+    'English and emoji short',
+); # end: 71f4a192-0566-4402-a512-fe12878be523
+
+is( # begin: 6f0f71f3-9806-4759-a844-fa182f7bc203
+    truncate_post("\xF0\x9F\x92\x87"),
+    '💇',
+    'Emoji short',
+); # end: 6f0f71f3-9806-4759-a844-fa182f7bc203
+
+is( # begin: ce71fb92-5214-46d0-a7f8-d5ba56b4cc6e
+    truncate_post("\xE2\x9D\x84\xF0\x9F\x8C\xA1\xF0\x9F\xA4\xA7\xF0\x9F\xA4\x92\xF0\x9F\x8F\xA5\xF0\x9F\x95\xB0\xF0\x9F\x98\x80"),
+    '❄🌡🤧🤒🏥',
+    'Emoji long',
+); # end: ce71fb92-5214-46d0-a7f8-d5ba56b4cc6e
+
+is( # begin: 5dee98d2-d56e-468a-a1f2-121c3f7c5a0b
+    truncate_post("\xF0\x9F\x83\x8E\xF0\x9F\x82\xB8\xF0\x9F\x83\x85\xF0\x9F\x83\x8B\xF0\x9F\x83\x8D\xF0\x9F\x83\x81\xF0\x9F\x83\x8A"),
+    '🃎🂸🃅🃋🃍',
+    'Royal Flush?',
+); # end: 5dee98d2-d56e-468a-a1f2-121c3f7c5a0b
+
+done_testing;


### PR DESCRIPTION
`slurp_utf8` already decodes the UTF-8 data from the file, causing the `utf8` option on the JSON object to complain about the data not being UTF-8 encoded. The `ascii` option escapes everything being output to the results JSON.